### PR TITLE
transfer of password functions to the service layer

### DIFF
--- a/backend/app/repositories/user.ts
+++ b/backend/app/repositories/user.ts
@@ -1,17 +1,11 @@
 import { ObjectId } from 'mongodb';
 import { HydratedDocument } from 'mongoose';
 import { User, IUser } from '../models/user';
-import bcrypt from 'bcrypt';
-const SALT_ROUNDS = 10;
 
 export class UserRepository {
   static async create(
-    email: string,
-    password: string,
+    user: HydratedDocument<IUser>,
   ): Promise<HydratedDocument<IUser>> {
-    const user = new User({ email, password });
-    const hash = await bcrypt.hash(user.password, SALT_ROUNDS);
-    user.password = hash;
     await user.save();
     return user;
   }
@@ -27,21 +21,29 @@ export class UserRepository {
     return await User.findByIdAndDelete(userId);
   }
 
-  static async findById(userId: string): Promise<HydratedDocument<IUser> | null>  {
+  static async findById(
+    userId: string,
+  ): Promise<HydratedDocument<IUser> | null> {
     return await User.findById(userId);
   }
 
-  static async findByEmail(email: string): Promise<HydratedDocument<IUser> | null>  {
+  static async findByEmail(
+    email: string,
+  ): Promise<HydratedDocument<IUser> | null> {
     return await User.findOne({ email });
   }
 
-  static async findUserByRole(role: string): Promise<HydratedDocument<IUser> | null>  {
+  static async findUserByRole(
+    role: string,
+  ): Promise<HydratedDocument<IUser> | null> {
     return await User.findOne({
       role,
     });
   }
 
-  static async findUsersByRole(role: string): Promise<HydratedDocument<IUser>[]> {
+  static async findUsersByRole(
+    role: string,
+  ): Promise<HydratedDocument<IUser>[]> {
     return await User.find({
       role,
     });
@@ -51,48 +53,21 @@ export class UserRepository {
     return await User.find();
   }
 
-  static async findUsersVerifiedEmail(email: string): Promise<HydratedDocument<IUser>[]> {
+  static async findUsersVerifiedEmail(
+    email: string,
+  ): Promise<HydratedDocument<IUser>[]> {
     return await User.find({
       email,
       'challenge.email.verified': true,
     });
   }
 
-  static async findUsersNotVerifiedEmail(email: string): Promise<HydratedDocument<IUser>[]> {
+  static async findUsersNotVerifiedEmail(
+    email: string,
+  ): Promise<HydratedDocument<IUser>[]> {
     return await User.find({
       email,
       'challenge.email.verified': false,
     });
-  }
-
-  static async findByEmailAndPassword(email: string, password: string) : Promise<HydratedDocument<IUser> | null> {
-    const user = await this.findByEmail(email);
-    if (!user) {
-      return null;
-    }
-    const isPasswordCorrect = await this._comparePassword(user, password);
-    if (!isPasswordCorrect) {
-      return null;
-    }
-    return user;
-  }
-
-  static async changePassword(
-    userId: ObjectId,
-    newPassword: string,
-  ): Promise<HydratedDocument<IUser> | null> {
-    const hash = await bcrypt.hash(newPassword, SALT_ROUNDS);
-    return await User.findByIdAndUpdate(
-      userId,
-      { password: hash },
-      { new: true },
-    );
-  }
-
-  private static async _comparePassword(
-    user: IUser,
-    password: string,
-  ): Promise<boolean> {
-    return await bcrypt.compare(password, user.password);
   }
 }

--- a/backend/app/services/session.ts
+++ b/backend/app/services/session.ts
@@ -2,13 +2,14 @@ import { StatusCodes } from 'http-status-codes';
 import { UserService } from './user';
 import { UserRepository } from '../repositories/user';
 import { RequestError } from '../helpers/error';
+import bcrypt from 'bcrypt';
 
 export class SessionService {
   static async login(
     email: string,
     password: string,
-  ): Promise<{ token: string }> {
-    const user = await UserRepository.findByEmailAndPassword(email, password);
+  ): Promise<{ token: string } | null> {
+    const user = await UserRepository.findByEmail(email);
 
     if (!user) {
       throw new RequestError(StatusCodes.UNAUTHORIZED, 'invalid_credentials');
@@ -16,6 +17,11 @@ export class SessionService {
 
     if (!user.challenge.email.verified) {
       throw new RequestError(StatusCodes.UNAUTHORIZED, 'email_not_verified');
+    }
+
+    const isPasswordCorrect = await bcrypt.compare(password, user.password);
+    if (!isPasswordCorrect) {
+      throw new RequestError(StatusCodes.UNAUTHORIZED, 'wrong_password');
     }
 
     return {


### PR DESCRIPTION
PR pour sortir les fonctions de mot de passe dans la couche service.

En faisant les modifs je me suis rendu compte que ce serait pratique de faire une sorte de userBuilder afin de construire des users et les envoyer au Repository. Car maintenant la couche service construit un user et l'envoie au Repository afin de le créer, même ça je ne sais pas si c'est une bonne pratique dis-moi ce que vous en pensez.