### PR TITLE
chore: remove package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "sneakpeak",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Résidu d'un npm install à la racine du projet plutôt que dans un des deux répertoires backend ou frontend